### PR TITLE
Also call onTap callback when hideBarsOnTap is false

### DIFF
--- a/Picture.kt
+++ b/Picture.kt
@@ -116,8 +116,8 @@ fun Picture(
             onTap = {
                 if (zoomParams.hideBarsOnTap) {
                     activity?.apply { if (isSystemBarsHidden) showSystemBars() else hideSystemBars() }
-                    zoomParams.onTap(it)
                 }
+                zoomParams.onTap(it)
             },
             content = { image() }
         )


### PR DESCRIPTION
Thanks for this great library!
I found that the onTap callback only gets triggered when hideBarsOnTap is set to true.
In my case, this is not the desired behaviour, so if there isn't a specific reason for this, I created this pull request.